### PR TITLE
feat: add option to pass the version in the inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ For a real-world example, have a look at my WinGet package updater repository: [
   - **Required**: ✅
   - **Example 1**: `https://github.com/michidk/vscli/releases/download/v{VERSION}/vscli-x86_64-pc-windows-msvc.zip`
   - **Example 2**: `url: '"https://github.com/michidk/vscli/releases/download/v{VERSION}/vscli-x86_64-pc-windows-msvc.zip https://github.com/michidk/vscli/releases/download/v{VERSION}/vscli-i686-pc-windows-msvc.zip"'`
+- `version`: Manually specify the version. This is useful for cases where the latest release's tag doesn't follow the `vX.X.X` or `x.x.x` patterns.
+  - **Required**: ❌
+  - **Example**: `1.0.0`
 - `custom-fork-owner`: The owner of the `winget-pkgs` repo fork to use. If not specified, the owner of the repository where the action is used will be used.
   - **Required**: ❌
   - **Example**: `michidk`

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   url:
     description: 'The URL(s) to the latest release.'
     required: true
+  version:
+    description: 'Override the auto-detected version.'
+    required: false
   custom-fork-owner:
     description: 'Custom winget-pkgs fork owner'
     required: false
@@ -62,12 +65,13 @@ runs:
     - name: Compose URL
       shell: bash
       run: |
-        VERSION=${{ steps.latest_release.outputs.result }}
+        VERSION=${{ inputs.version || steps.latest_release.outputs.result }}
         URL=${{ inputs.url }}
         FINAL_URL=$(echo $URL | sed "s/{VERSION}/$VERSION/g")
         echo "FINAL_URL=$FINAL_URL" >> $GITHUB_ENV
-        echo "Detected latest Version: ${{ steps.latest_release.outputs.result }}"
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
         echo "Final URL: $FINAL_URL"
+        echo "Version: $VERSION"
 
     - name: Run Komac
       uses: michidk/run-komac@v2
@@ -77,4 +81,4 @@ runs:
         custom-fork-owner: ${{ inputs.custom-fork-owner }}
         custom-tool: WinGet Updater
         custom-tool-url: "https://github.com/michidk/winget-updater"
-        args: update ${{ inputs.identifier }} --version ${{ steps.latest_release.outputs.result }} --urls $FINAL_URL --submit --token ${{ inputs.komac-token }}
+        args: update ${{ inputs.identifier }} --version $VERSION --urls $FINAL_URL --submit --token ${{ inputs.komac-token }}


### PR DESCRIPTION
I came across a special case where the auto-detected version doesn't work as expected because the tag is not a `v1.2.3` or `1.2.3`, but instead something like `core@1.2.3`. Adding an optional `version` input solved the issue for me, so I thought I'd contribute to upstream in case anyone finds it useful as well.