### PR TITLE
ci: move from aslafy-z/conventional-pr-title-action to amannn/action-semantic-pull-request

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - uses: aslafy-z/conventional-pr-title-action@v3
+      - uses: amannn/action-semantic-pull-request@v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
https://github.com/aslafy-z/conventional-pr-title-action#important-notice-this-repository-has-been-archived
Example usage: https://github.com/topgrade-rs/topgrade/blob/main/.github/workflows/lint_pr.yml
Docs: https://github.com/amannn/action-semantic-pull-request