### PR TITLE
docs: fix error in `custom-fork-owner` input description

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ For a real-world example, have a look at my WinGet package updater repository: [
 - `version`: Manually specify the version. This is useful for cases where the latest release's tag doesn't follow the `vX.X.X` or `x.x.x` patterns.
   - **Required**: ❌
   - **Example**: `1.0.0`
-- `custom-fork-owner`: The owner of the `winget-pkgs` repo fork to use. If not specified, the owner of the repository where the action is used will be used.
+- `custom-fork-owner`: The owner of the `winget-pkgs` repo fork to use. If not specified, the user that created the `komac-token`.
   - **Required**: ❌
   - **Example**: `michidk`
 


### PR DESCRIPTION
Workflow file:
```yml
name: Publish to WinGet

on:
  repository_dispatch:
    types: [ release-assets-built ]
  workflow_dispatch:

jobs:
  publish:
    runs-on: ubuntu-latest
    steps:
      - uses: michidk/winget-updater@3045a0d80c3ac5eee06d38bbe4174df74119099c # v1.1.6
        with:
          komac-token: ${{ secrets.WINGET_TOKEN }}
          identifier: topgrade-rs.topgrade
          repo: topgrade-rs/topgrade
          url: "https://github.com/topgrade-rs/topgrade/releases/download/v{VERSION}/topgrade-v{VERSION}-x86_64-pc-windows-msvc.zip"
```
But I get an error when running the workflow in `topgrade-rs/topgrade`:
```
Error: 
   0: No repository was returned when requesting repository information for GideonBear/winget-pkgs
```
https://github.com/topgrade-rs/topgrade/actions/runs/20299941044/job/58302748524
I assume komac uses the token's user when not specified.
https://github.com/michidk/run-komac/blob/42850f04bf386869019d9889ed232af44e179d38/action.yml#L57-L59

You made the thing, so correct me if I'm wrong, but it looks like the current docs are wrong or unclear :)