### PR TITLE
fix: don't silently ignore errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,6 @@ runs:
 
     - name: Run Komac
       uses: michidk/run-komac@v2
-      continue-on-error: true
       with:
         komac-version: ${{ inputs.komac-version }}
         custom-fork-owner: ${{ inputs.custom-fork-owner }}


### PR DESCRIPTION
Closes #24
Removes `continue-on-error: true` from `Run Komac`.